### PR TITLE
Fix missing host requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 667459f84c4159e1104a809518d53d2906888b2dcece83a377f16685bbcdfe9b
 
 build:
-  number: 1
+  number: 2
   noarch: python
   entry_points:
     - qhub = qhub.__main__:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
   host:
     - python >=3.7,<4.0
     - pip
+    - setuptools_scm
   run:
     - python >=3.7,<4.0
     - auth0-python
@@ -44,6 +45,7 @@ test:
   commands:
     - pip check
     - qhub --help
+    - if [[ $(qhub --version) == {{ version }} ]]; then return 1; else return 0; fi
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ test:
   commands:
     - pip check
     - qhub --help
-    - if [[ $(qhub --version) == {{ version }} ]]; then return 1; else return 0; fi
+    - if [[ $(qhub --version) != {{ version }} ]]; then exit 1; else exit 0; fi
   requires:
     - pip
 


### PR DESCRIPTION
From `0.3.14` to `0.4.0` onwards, qhub switched its version system to use `setuptools_scm`, unfortunately, conda does not pick this dependency automatically during the build process which leads to the package version being incorrectly set as `0.0.0`. To fix this, `setuptools_scm` was added to the host's requirements, fixing the version issue.

- Added `setuptools_scm` to Hosts
- Added test command to assert meta version with client version

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
